### PR TITLE
Add method to get the underlying `Progressbar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,14 @@ the maximum count of items to process:
         
         $spinner->finish();
     } 
-    
-   
+
+You can also get the underlying `ProgressBar` instance if you want to change anything, for example adding the elapsed time to the output format:
+
+```php
+$spinner = new SpinnerProgress($output, 100);
+$spinner->getProgressBar()->setFormat('%bar% (%elapsed:6s%) %message%');
+```
+
 ## License
 
 This package is released under the [MIT license](LICENSE).

--- a/src/SpinnerProgress.php
+++ b/src/SpinnerProgress.php
@@ -47,4 +47,9 @@ class SpinnerProgress
     {
         $this->progressBar->finish();
     }
+
+    public function getProgressBar(): ProgressBar
+    {
+        return $this->progressBar;
+    }
 }


### PR DESCRIPTION
Closes #4

I decided to just add a getter method for the progressbar, as this provides a way to do what I wanted in that issue and also lets people do literally whatever else they might want to do with the progressbar going forward.