### PR TITLE
FIX Don't use API that doesn't exist on OutputInterface

### DIFF
--- a/src/SpinnerProgress.php
+++ b/src/SpinnerProgress.php
@@ -22,7 +22,7 @@ class SpinnerProgress
 
     public function __construct(OutputInterface $output, int $max = 0)
     {
-        $this->progressBar = new ProgressBar($output->section(), $max);
+        $this->progressBar = new ProgressBar($output, $max);
         $this->progressBar->setBarCharacter('✔');
         $this->progressBar->setFormat('%bar%  %message%');
         $this->progressBar->setBarWidth(1);


### PR DESCRIPTION
The `section()` method doesn't exist on `OutputInterface` - The other option is to restrict this so it can only be used with some implementation that does have that method, but it's way more useful this way - people can just pass in a section if that's what they want.

It's not even immediately clear what class this was intended to have passed into it - `SymfonyStyle` implements a `section()` method for example, but that doesn't return anything...